### PR TITLE
Make use of WikiParser for compat. parsing.

### DIFF
--- a/wrapper.js
+++ b/wrapper.js
@@ -36,68 +36,14 @@ Wraps up the markdown-it parser for use in TiddlyWiki5
         liClass: 'c-task-list__item'
     });
 
-    const tiddlify = (node, forceText) => {
-        if (node.nodeType === Node.TEXT_NODE) {
-            let subtree;
-            try {
-                const children = new $tw.Wiki.parsers[TYPE_WIKI](TYPE_WIKI, node.textContent, {}).tree[0].children;
-                if (children.length === 0) {
-                    subtree = null;
-                }
-                else if (children.length === 1) {
-                    subtree = children[0];
-                }
-                else {
-                    subtree = {
-                        type: 'element',
-                        tag: 'span',
-                        children: children,
-                    };
-                }
-            }
-            catch(error) {
-                subtree = null;
-            }
-            if (!forceText && subtree) {
-                return subtree;
-            }
-            else {
-                return {
-                    text: node.textContent,
-                    type: 'text'
-                };
-            }
-        }
-        if (node.tagName) {
-            const widget = {
-                attributes: {},
-                tag: node.tagName.toLowerCase(),
-                type: 'element'
-            };
-            $tw.utils.each(node.attributes, (attribute) => {
-                widget.attributes[attribute.nodeName] = {
-                    type: 'string',
-                    value: attribute.nodeValue
-                };
-            });
-            widget.children = [];
-            node.childNodes.forEach((child) => {
-                const isPlainText = (
-                    forceText ||
-                    widget.tag === 'code' ||
-                    widget.tag === 'a'
-                );
-                widget.children.push(tiddlify(child, isPlainText));
-            });
-            return widget;
-        }
-    };
-
     class MarkdownParser {
         constructor(type, text, options) {
             const source = markdown.render(text);
-            const tree = dom.parseFromString(source, 'text/html');
-            this.tree = tiddlify(tree.body).children;
+            const wikiParser = new $tw.Wiki.parsers[TYPE_WIKI](
+                TYPE_WIKI,
+                source, options
+            );
+            this.tree = wikiParser.tree;
         }
     }
 


### PR DESCRIPTION
This patch makes MarkdownParser rely on WikiParser to parse WikiText
instead of hackish low-level recursive code previously encapsulated
in tiddlify() function.

Addresses #7.